### PR TITLE
[ch19928] Implement deploy command with a review env chart

### DIFF
--- a/.codefresh/build/pipeline.yml
+++ b/.codefresh/build/pipeline.yml
@@ -1,28 +1,41 @@
 version: "1.0"
 stages:
-  - "clone"
-  - "build"
-  - "run"
+  - clone
+  - helm
+  - build
 
 steps:
   clone:
-    title: "Cloning repository"
-    type: "git-clone"
-    repo: "FindHotel/cf-review-env"
-    revision: "${{CF_BRANCH}}"
-    git: "github"
-    stage: "clone"
+    title: Cloning repository
+    type: git-clone
+    repo: FindHotel/cf-review-env
+    revision: ${{CF_BRANCH}}
+    git: github
+    stage: clone
+
+  push:
+    stage: helm
+    title: Push to the Repository
+    type: helm
+    working_directory: ./cf-review-env
+    arguments:
+      action: push
+      helm_version: ${{K8S_HELM_VERSION}}
+      chart_name: charts/cf-review-env
+      chart_repo_url: ${{K8S_CHART_REPOSITORY}}
+      skip_cf_stable_helm_repo: true
+      kube_context: ${{K8S_CONTEXT_NAME}}
 
   build:
-    title: "Building Docker image"
-    type: "build"
+    title: Building Docker image
+    type: build
     image_name: ${{IMAGE_NAME}}
-    working_directory: "${{clone}}"
+    working_directory: ${{clone}}
     tag: latest
     tags:
-      - "${{CF_SHORT_REVISION}}"
-      - "${{CF_BRANCH_TAG_NORMALIZED}}"
+      - ${{CF_SHORT_REVISION}}
+      - ${{CF_BRANCH_TAG_NORMALIZED}}
       - latest
-    dockerfile: "Dockerfile"
-    stage: "build"
+    dockerfile: Dockerfile
+    stage: build
     registry: ${{IMAGE_REGISTRY_NAME}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
-FROM golang:1.14-alpine
+FROM golang:1.14-alpine as base
 
 RUN apk add --no-cache git
-
 WORKDIR /
 
 COPY prune/* ./
-
 RUN go build -o ./prune .
 RUN chmod +x prune
+
+FROM codefresh/cfstep-helm:3.0.3
+RUN apk add --no-cache libstdc++
+RUN curl -L "https://github.com/codefresh-io/cli/releases/download/v0.71.3/codefresh-v0.71.3-alpine-x64.tar.gz" -o codefresh.tar.gz \
+    && tar -zxvf codefresh.tar.gz \
+    && mv ./codefresh /usr/local/bin/codefresh
+RUN chmod +x /usr/local/bin/codefresh
+
+WORKDIR /
+COPY deploy/* ./
+RUN chmod +x deploy
+
+# We need to do this because cfstep-helm has an entrypoint
+ENTRYPOINT []

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,6 @@
+Website Helm Chart
+==================
+
+This is a `website helm chart` created by helm.
+
+Ref.: https://helm.sh/docs/helm/helm_create/

--- a/charts/cf-review-env/.helmignore
+++ b/charts/cf-review-env/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/cf-review-env/Chart.yaml
+++ b/charts/cf-review-env/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+appVersion: 1.16.0
+name: cf-review-env
+description: A Helm chart a CloudFresh review envrionment app
+keywords:
+  - review
+  - environment
+maintainers:
+  - name: FH EEQ Team
+type: application
+sources:
+- https://github.com/FindHotel/cf-review-env
+version: 0.1.0

--- a/charts/cf-review-env/templates/NOTES.txt
+++ b/charts/cf-review-env/templates/NOTES.txt
@@ -1,0 +1,8 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cf-review-env/templates/_helpers.tpl
+++ b/charts/cf-review-env/templates/_helpers.tpl
@@ -1,0 +1,64 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cf-review-env.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cf-review-env.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cf-review-env.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cf-review-env.labels" -}}
+helm.sh/chart: {{ include "cf-review-env.chart" . }}
+{{ include "cf-review-env.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cf-review-env.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cf-review-env.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cf-review-env.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cf-review-env.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/cf-review-env/templates/deployment.yaml
+++ b/charts/cf-review-env/templates/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cf-review-env.fullname" . }}
+  labels:
+    {{- include "cf-review-env.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  strategy:
+{{- if .Values.strategy }}
+{{ toYaml .Values.strategy | indent 4 }}
+{{- end }}
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "cf-review-env.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "cf-review-env.selectorLabels" . | nindent 8 }}
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecrets }}
+      serviceAccountName: {{ include "cf-review-env.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.envFrom.secretRef.name }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envFrom.secretRef.name }}
+          {{- end }}
+          ports:
+            - name: {{ .Values.deployment.ports.name }}
+              containerPort: {{ .Values.deployment.ports.containerPort }}
+              protocol: {{ .Values.deployment.ports.protocol }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.httpGet.path}}
+              port: {{ .Values.service.port}}
+              scheme: {{ .Values.livenessProbe.httpGet.scheme}}
+            initialDelaySeconds: {{ .Values.livenessProbe.httpGet.initialDelaySeconds}}
+            timeoutSeconds: {{ .Values.livenessProbe.httpGet.timeoutSeconds}}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.httpGet.path}}
+              port: {{ .Values.service.port}}
+              scheme: {{ .Values.readinessProbe.httpGet.scheme}}
+            initialDelaySeconds: {{ .Values.readinessProbe.httpGet.initialDelaySeconds}}
+            timeoutSeconds: {{ .Values.readinessProbe.httpGet.timeoutSeconds}}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: {{ .Values.restartPolicy }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      dnsPolicy: {{ .Values.dnsPolicy }}

--- a/charts/cf-review-env/templates/hpa.yaml
+++ b/charts/cf-review-env/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cf-review-env.fullname" . }}
+  labels:
+    {{- include "cf-review-env.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cf-review-env.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/charts/cf-review-env/templates/ingress.yaml
+++ b/charts/cf-review-env/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "cf-review-env.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "cf-review-env.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/cf-review-env/templates/service.yaml
+++ b/charts/cf-review-env/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cf-review-env.fullname" . }}
+  labels:
+    {{- include "cf-review-env.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: {{ .Values.service.name }}
+      protocol: {{ .Values.service.protocol }}
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+  selector:
+    {{- include "cf-review-env.selectorLabels" . | nindent 4 }}

--- a/charts/cf-review-env/templates/serviceaccount.yaml
+++ b/charts/cf-review-env/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cf-review-env.serviceAccountName" . }}
+  labels:
+    {{- include "cf-review-env.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cf-review-env/templates/tests/test-connection.yaml
+++ b/charts/cf-review-env/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "cf-review-env.fullname" . }}-test-connection"
+  labels:
+    {{- include "cf-review-env.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "cf-review-env.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -1,0 +1,35 @@
+#!/bin/sh
+export NAMESPACE=re-$NAME
+kubectl config use-context $KUBE_CONTEXT
+kubectl create namespace $NAMESPACE --dry-run -o yaml | kubectl apply -f -
+kubectl create secret generic $NAMESPACE --from-env-file=/codefresh/volume/secrets.env --dry-run -o yaml --save-config=true --namespace $NAMESPACE | kubectl apply -f -
+codefresh generate image-pull-secret --cluster $KUBE_CONTEXT --namespace $NAMESPACE --registry $APP_REGISTRY_NAME
+
+# We need to use env here because of the CUSTOM vars
+# they have special charectes that export can't handle
+env \
+ACTION=install \
+CHART_REPO_URL=cm://h.cfcr.io/findhotel/default \
+CHART_REF=cf-review-env \
+KUBE_CONTEXT=$KUBE_CONTEXT \
+RELEASE_NAME=$NAME \
+HELM_VERSION=3.0.3 \
+CUSTOM_image_tag=$APP_IMAGE_TAG \
+CUSTOM_image_repository=$APP_IMAGE_URL \
+CUSTOM_imagePullSecrets=$(kubectl get secret --namespace $NAMESPACE --field-selector='type=kubernetes.io/dockercfg' -o=jsonpath='{.items[0].metadata.name}') \
+CUSTOM_envFrom_secretRef_name=$NAMESPACE \
+CUSTOM_"ingress_hosts[0]_host=$NAMESPACE.$APP_DOMAIN" \
+CUSTOM_"ingress_hosts[0]_paths[0]=/" \
+CUSTOM_"ingress_tls[0]_secretName=$NAMESPACE-tls" \
+CUSTOM_"ingress_tls[0]_hosts[0]=$NAMESPACE.$APP_DOMAIN" \
+CUSTOMFILE_0=$VALUES_FILE \
+SKIP_CF_STABLE_HELM_REPO=true \
+WAIT=true \
+/opt/bin/release_chart
+
+env ACTION=auth \
+SKIP_CF_STABLE_HELM_REPO=true \
+HELM_VERSION=3.0.3 \
+KUBE_CONTEXT=$KUBE_CONTEXT \
+/opt/bin/release_chart
+helm test $NAME --namespace $NAMESPACE


### PR DESCRIPTION
Add a deploy command that can be used to install the review env chart. 

The helm chart was originally developed internally. In this PR I'm mostly copying and changing the name. 