### PR TITLE
[ch20441] Use labels to identify cf-review deployments to be pruned

### DIFF
--- a/.codefresh/auto-prune/pipeline.yml
+++ b/.codefresh/auto-prune/pipeline.yml
@@ -8,6 +8,6 @@ steps:
     type: freestyle
     stage: run
     # This has to be the full image uri otherwise it doesn't work
-    image: ${{IMAGE_REGISTRY_URL}}/${{IMAGE_NAME}}:latest
+    image: ${{IMAGE_REGISTRY_URL}}/${{IMAGE_NAME}}:${{IMAGE_TAG}}
     commands:
       - "/prune --cfToken=$CF_TOKEN --k8sKubeconfig=$CF_KUBECONFIG_PATH --k8sContextName=$K8S_CONTEXT_NAME --name=re-*"

--- a/.codefresh/auto-prune/spec.yml
+++ b/.codefresh/auto-prune/spec.yml
@@ -23,6 +23,6 @@ spec:
     location: git
     repo: FindHotel/cf-review-env
     path: ./.codefresh/auto-prune/pipeline.yml
-    revision: master
+    revision: ch20441
     context: github
 

--- a/.codefresh/auto-prune/spec.yml
+++ b/.codefresh/auto-prune/spec.yml
@@ -23,6 +23,6 @@ spec:
     location: git
     repo: FindHotel/cf-review-env
     path: ./.codefresh/auto-prune/pipeline.yml
-    revision: ch20441
+    revision: master
     context: github
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM codefresh/cfstep-helm:3.0.3
 ARG DEFAULT_HELM_REPO_URL
 ENV HELM_REPO_URL $DEFAULT_HELM_REPO_URL
 
-RUN apk update && apk add --no-cache rhash && apk add --no-cache libstdc++
+RUN apk update && apk add --no-cache rhash gettext libstdc++
 RUN curl -L "https://github.com/codefresh-io/cli/releases/download/v0.71.3/codefresh-v0.71.3-alpine-x64.tar.gz" -o codefresh.tar.gz \
     && tar -zxvf codefresh.tar.gz \
     && mv ./codefresh /usr/local/bin/codefresh

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -6,8 +6,23 @@ chart_ref=cf-review-env
 SHORT_NAME=$(echo -n $NAME | cut -c1-20)
 HASH=$(echo $NAME | rhash -p "%c" -)
 export NAMESPACE=re-$SHORT_NAME-$HASH
+export UPDATED_AT=$(date --utc +%s)
 kubectl config use-context $KUBE_CONTEXT
-kubectl create namespace $NAMESPACE --dry-run -o yaml | kubectl apply -f -
+
+kubectl version
+cat <<EOF | envsubst | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/instance: $NAMESPACE
+    app.kubernetes.io/name: cf-review-env
+    app.kubernetes.io/pull_request_number: "$CF_PULL_REQUEST_NUMBER"
+    app.kubernetes.io/repository_name: "$CF_REPO_NAME"
+    app.kubernetes.io/repository_owner: "$CF_REPO_OWNER"
+    app.kubernetes.io/updated_at: "$UPDATED_AT"
+  name: $NAMESPACE
+EOF
 kubectl create secret generic $NAMESPACE --from-env-file=/codefresh/volume/secrets.env --dry-run -o yaml --save-config=true --namespace $NAMESPACE | kubectl apply -f -
 codefresh generate image-pull-secret --cluster $KUBE_CONTEXT --namespace $NAMESPACE --registry $APP_REGISTRY_NAME
 


### PR DESCRIPTION
Add labels to the k8s namespace that we create for each deployment. The labels will then be used when search for all cf-review-envs in the cluster, but also to get the update at time and later on the pr number.