### PR TITLE
[ch20623] - change the size of the namespace name

### DIFF
--- a/deploy/deploy
+++ b/deploy/deploy
@@ -3,7 +3,7 @@ chart_version=0.2.0
 helm_version=3.0.3
 chart_ref=cf-review-env
 
-SHORT_NAME=$(echo -n $NAME | cut -c1-20)
+SHORT_NAME=$(echo -n $NAME | cut -c1-15)
 HASH=$(echo $NAME | rhash -p "%c" -)
 export NAMESPACE=re-$SHORT_NAME-$HASH
 kubectl config use-context $KUBE_CONTEXT


### PR DESCRIPTION
[ch20623](https://app.clubhouse.io/findhotel/story/20623/check-validation-time-of-ssl-certificate-cert-manager-service)

It is necessary to change the number of characters of the `namespace` name because today we are using the variable `$NAMESPACE` to create the URL (ingress host) for the review environment and the number of characters is too long for the `letsencrypt` service validate the SSL certificate.

Ref.:

- https://community.letsencrypt.org/t/ssl-for-a-63-character-max-number-of-characters-domain-name-s/36387
- https://github.com/certbot/certbot/issues/1915