### PR TITLE
[ch21204] - Added new version of the kubectl command line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,13 @@ ARG DEFAULT_HELM_REPO_URL
 ENV HELM_REPO_URL $DEFAULT_HELM_REPO_URL
 
 RUN apk update && apk add --no-cache rhash gettext libstdc++
-RUN curl -L "https://github.com/codefresh-io/cli/releases/download/v0.71.3/codefresh-v0.71.3-alpine-x64.tar.gz" -o codefresh.tar.gz \
+RUN curl -L "https://github.com/codefresh-io/cli/releases/download/v0.72.1/codefresh-v0.72.1-alpine-x64.tar.gz" -o codefresh.tar.gz \
     && tar -zxvf codefresh.tar.gz \
     && mv ./codefresh /usr/local/bin/codefresh
 RUN chmod +x /usr/local/bin/codefresh
+
+RUN curl -L "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl"
+RUN mv kubectl /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 
 WORKDIR /
 COPY deploy/* ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -L "https://github.com/codefresh-io/cli/releases/download/v0.72.1/codef
     && mv ./codefresh /usr/local/bin/codefresh
 RUN chmod +x /usr/local/bin/codefresh
 
-RUN curl -L "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl"
+RUN curl -LO --silent "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl"
 RUN mv kubectl /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 
 WORKDIR /

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -27,7 +27,7 @@ metadata:
     app.kubernetes.io/updated_at: "$UPDATED_AT"
   name: $NAMESPACE
 EOF
-kubectl create secret generic $NAMESPACE --from-env-file=/codefresh/volume/secrets.env --dry-run -o yaml --save-config=true --namespace $NAMESPACE | kubectl apply -f -
+kubectl create secret generic $NAMESPACE --from-env-file=/codefresh/volume/secrets.env --dry-run=client -o yaml --save-config=true --namespace $NAMESPACE | kubectl apply -f -
 codefresh generate image-pull-secret --cluster $KUBE_CONTEXT --namespace $NAMESPACE --registry $APP_REGISTRY_NAME
 
 # We need to use env here because of the CUSTOM vars

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -2,15 +2,13 @@
 chart_version=0.2.0
 helm_version=3.0.3
 chart_ref=cf-review-env
-kubectl_version=v1.18.6
 
 SHORT_NAME=$(echo -n $NAME | cut -c1-15)
 HASH=$(echo $NAME | rhash -p "%c" -)
 export NAMESPACE=re-$SHORT_NAME-$HASH
 export UPDATED_AT=$(date --utc +%s)
 
-curl -LO --silent https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/linux/amd64/kubectl
-chmod u+x kubectl && mv kubectl /usr/local/bin && kubectl version
+kubectl version
 
 kubectl config use-context $KUBE_CONTEXT
 

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -2,14 +2,18 @@
 chart_version=0.2.0
 helm_version=3.0.3
 chart_ref=cf-review-env
+kubectl_version=v1.18.6
 
 SHORT_NAME=$(echo -n $NAME | cut -c1-15)
 HASH=$(echo $NAME | rhash -p "%c" -)
 export NAMESPACE=re-$SHORT_NAME-$HASH
 export UPDATED_AT=$(date --utc +%s)
+
+curl -LO --silent https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/linux/amd64/kubectl
+chmod u+x kubectl && mv kubectl /usr/local/bin && kubectl version
+
 kubectl config use-context $KUBE_CONTEXT
 
-kubectl version
 cat <<EOF | envsubst | kubectl apply -f -
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
[ch21204](https://app.clubhouse.io/findhotel/story/21204/check-the-memory-metrics-on-the-hpa-file-in-the-helm-chart)

- The `kubectl` command needs to update because in our `helm templates` we are checking the version from the command to use the current `apiVersion`.
- `--dry-run` is deprecated and can be replaced with `--dry-run=client`

For example: 

`{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}`

Note: I trying to update it with the intent to fix the problem with HPA metrics from the pods.