### PR TITLE
Improvement to connection test

### DIFF
--- a/charts/cf-review-env/Chart.yaml
+++ b/charts/cf-review-env/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 type: application
 sources:
 - https://github.com/FindHotel/cf-review-env
-version: 0.2.1
+version: 0.2.2

--- a/charts/cf-review-env/templates/tests/test-connection.yaml
+++ b/charts/cf-review-env/templates/tests/test-connection.yaml
@@ -8,8 +8,12 @@ metadata:
     "helm.sh/hook": test-success
 spec:
   containers:
-    - name: wget
+  {{- range $index, $host := .Values.ingress.hosts }}
+    {{- range .paths }}
+    - name: wget{{ $index }}
       image: busybox
       command: ['wget']
-      args: ['{{ include "cf-review-env.fullname" . }}:{{ .Values.service.port }}']
+      args: ['http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}']
+    {{- end }}
+  {{- end }}
   restartPolicy: Never

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -1,5 +1,5 @@
 #!/bin/sh
-chart_version=0.2.1
+chart_version=${CHART_VERSION:-0.2.2}
 helm_version=3.0.3
 chart_ref=cf-review-env
 

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -50,24 +50,30 @@ SKIP_CF_STABLE_HELM_REPO=true \
 WAIT=true \
 /opt/bin/release_chart
 
-env ACTION=auth \
-SKIP_CF_STABLE_HELM_REPO=true \
-HELM_VERSION=$helm_version \
-CHART_VERSION=$chart_version \
-KUBE_CONTEXT=$KUBE_CONTEXT \
-/opt/bin/release_chart
-helm test $NAMESPACE --namespace $NAMESPACE
+TEST_CONNECTION=${TEST_CONNECTION:-true}
+if [[ "$TEST_CONNECTION" = true ]];
+then
+  env ACTION=auth \
+  SKIP_CF_STABLE_HELM_REPO=true \
+  HELM_VERSION=$helm_version \
+  CHART_VERSION=$chart_version \
+  KUBE_CONTEXT=$KUBE_CONTEXT \
+  /opt/bin/release_chart
+  helm test $NAMESPACE --namespace $NAMESPACE
 
-helm_test_status=$(kubectl get pods --selector="app.kubernetes.io/managed-by=Helm" -o jsonpath='{.items[?(@.status.phase!="Succeeded")].status.phase}' --cluster $KUBE_CONTEXT --namespace $NAMESPACE)
-if [[ "$helm_test_status" == "Failed" ]]; then
-  echo "ERROR: The branch has not passed because the Helm Test failed, please check your application pod.";
-  exit 1;
+  helm_test_status=$(kubectl get pods --selector="app.kubernetes.io/managed-by=Helm" -o jsonpath='{.items[?(@.status.phase!="Succeeded")].status.phase}' --cluster $KUBE_CONTEXT --namespace $NAMESPACE)
+  if [[ "$helm_test_status" == "Failed" ]]; then
+    echo "ERROR: The branch has not passed because the Helm Test failed, please check your application pod.";
+    exit 1;
+  else
+    # It is necessary to remove the test pod from the helm test bacause HPA metrics may fail when we have a pod with completed status.
+    # Issue: https://github.com/kubernetes/kubernetes/issues/79365
+    # Issues: https://github.com/kubernetes/kubernetes/issues?page=1&q=is%3Aissue+is%3Aopen+HPA
+    echo "INFO: Removed the completed Test Pod";
+    kubectl delete pod --selector="app.kubernetes.io/managed-by=Helm" --namespace $NAMESPACE
+  fi
 else
-  # It is necessary to remove the test pod from the helm test bacause HPA metrics may fail when we have a pod with completed status.
-  # Issue: https://github.com/kubernetes/kubernetes/issues/79365
-  # Issues: https://github.com/kubernetes/kubernetes/issues?page=1&q=is%3Aissue+is%3Aopen+HPA
-  echo "INFO: Removed the completed Test Pod";
-  kubectl delete pod --selector="app.kubernetes.io/managed-by=Helm" --namespace $NAMESPACE
+  echo "Connection test is disabled.";
 fi
 
 cf_export NAMESPACE=re-$SHORT_NAME-$HASH


### PR DESCRIPTION
During implementation of the website-proxy project I had problems with the connection test. Nginx only responds to requests of specific addresses, therefore the connection test was failing as it uses the local ip. On this PR I'm changing the connection test to use the ingress address, which is much better test to perform, as it will test the app end to end, and also make deployments like nginx work. I'm also introducing a parameter to disable the connection test if needed, and I'm making possible to specify the chart version, so we can test things easily.