### PR TITLE
[ch23168] Allow multiple concurrent deployments in the same kubectl

### DIFF
--- a/deploy/deploy
+++ b/deploy/deploy
@@ -10,6 +10,11 @@ hash=$(echo "$NAME" | rhash -p "%c" -)
 namespace=re-$short_name-$hash
 
 config_context() {
+  # kubectl locks the config for each execution. To workaround
+  # and allow multiple concurrent kubectl executions we copy the config
+  kubeconfig_dir=/codefresh/volume/sensitive/.kube-$namespace/
+  cp -R /codefresh/volume/sensitive/.kube "${kubeconfig_dir}"
+  export KUBECONFIG=${kubeconfig_dir}/config
   kubectl config use-context "$KUBE_CONTEXT"
 }
 


### PR DESCRIPTION
To allow multiple concurrent deployments of a review env we need to copy the kuke config folder for each execution. This is necessary because kubectl locks the config for each execution. This is needed in pipelines deploy multiple review envs concurrently, like the website one.