### PR TITLE
Chart bump version 025

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## Use startupProbe on the deployments
 
-We need to use the `startupProbe` in our helm chart, but this new feature will be available only on `EKS version 1.18`, so now we have it added in our [deployment.yaml](https://github.com/FindHotel/cf-review-env/blob/master/charts/cf-review-env/templates/deployment.yaml#L62) file but we can't use it.
+We need to use the `startupProbe` in our deployments, but this new feature will be available only on `EKS version 1.18`, so now we have it added in our [deployment.yaml](https://github.com/FindHotel/cf-review-env/blob/master/charts/cf-review-env/templates/deployment.yaml#L62) file but we can't use it.
 **Note:** According to AWS the `EKS 1.18 version` will be available on `October, 2020`.
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,10 @@
+# TODO
+
+## Use startupProbe on the deployments
+
+We need to use the `startupProbe` in our helm chart, but this new feature will be available only on `EKS version 1.18`, so now we have it added in our [deployment.yaml](https://github.com/FindHotel/cf-review-env/blob/master/charts/cf-review-env/templates/deployment.yaml#L62) file but we can't use it.
+**Note:** According to AWS the `EKS 1.18 version` will be available on `October, 2020`.
+
+
+Issue: https://github.com/aws/containers-roadmap/issues/947
+AWS Roadmap: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,5 @@
 We need to use the `startupProbe` in our deployments, but this new feature will be available only on `EKS version 1.18`, so now we have it added in our [deployment.yaml](https://github.com/FindHotel/cf-review-env/blob/master/charts/cf-review-env/templates/deployment.yaml#L62) file but we can't use it.
 **Note:** According to AWS the `EKS 1.18 version` will be available on `October, 2020`.
 
-
 Issue: https://github.com/aws/containers-roadmap/issues/947
 AWS Roadmap: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar

--- a/charts/cf-review-env/Chart.yaml
+++ b/charts/cf-review-env/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 type: application
 sources:
 - https://github.com/FindHotel/cf-review-env
-version: 0.2.4
+version: 0.2.5

--- a/charts/cf-review-env/templates/deployment.yaml
+++ b/charts/cf-review-env/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
               port: {{ .Values.deployment.ports.containerPort }}
               scheme: {{ .Values.startupProbe.httpGet.scheme | default "HTTP" }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds | default "5" }}
-            failureThreshold: {{ .Values.startupProbe.failureThreshold | default "100" }}   
+            failureThreshold: {{ .Values.startupProbe.failureThreshold | default "60" }}   
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if eq .Values.dockerDind.enabled true }}

--- a/charts/cf-review-env/templates/deployment.yaml
+++ b/charts/cf-review-env/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
               protocol: {{ .Values.deployment.ports.protocol | default "TCP" }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.livenessProbe.httpGet.path }}
+              path: {{ .Values.livenessProbe.httpGet.path | default "/" }}
               port: {{ .Values.deployment.ports.containerPort }}
               scheme: {{ .Values.livenessProbe.httpGet.scheme | default "HTTP" }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default "15" }}
@@ -52,7 +52,7 @@ spec:
             failureThreshold: {{ .Values.livenessProbe.failureThreshold | default "2" }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.readinessProbe.httpGet.path }}
+              path: {{ .Values.readinessProbe.httpGet.path | default "/" }}
               port: {{ .Values.deployment.ports.containerPort }}
               scheme: {{ .Values.readinessProbe.httpGet.scheme | default "HTTP" }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default "15" }}
@@ -61,7 +61,7 @@ spec:
             failureThreshold: {{ .Values.readinessProbe.failureThreshold | default "2" }}
           startupProbe:
             httpGet:
-              path: {{ .Values.startupProbe.httpGet.path| default "/" }}
+              path: {{ .Values.startupProbe.httpGet.path | default "/" }}
               port: {{ .Values.deployment.ports.containerPort }}
               scheme: {{ .Values.startupProbe.httpGet.scheme | default "HTTP" }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds | default "5" }}

--- a/charts/cf-review-env/values.yaml
+++ b/charts/cf-review-env/values.yaml
@@ -26,15 +26,6 @@ strategy:
   rollingUpdate:
     maxSurge: 1
     maxUnavailable: 0
-livenessProbe:
-  httpGet:
-    path: "/"
-readinessProbe:
-  httpGet:
-    path: "/"
-startupProbe:
-  httpGet:
-    path: "/"
 envFrom:
   enabled: true
 dockerDind:

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -2,7 +2,7 @@
 # exit if any command fails
 set -e
 
-chart_version=${CHART_VERSION:-0.2.4}
+chart_version=${CHART_VERSION:-0.2.5}
 helm_version=3.0.3
 chart_ref=cf-review-env
 short_name=$(echo -n $NAME | cut -c1-15)


### PR DESCRIPTION
- Added new bump version
- Added default value for the startupProbe and livenessProbe
- Changed the time of failureThreshold from 100 to 60
- Deploy script updated with new bump version