### PR TITLE
[ch24233] - chart bump version 028

### DIFF
--- a/charts/cf-review-env/Chart.yaml
+++ b/charts/cf-review-env/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.2.7
+appVersion: 0.2.8
 name: cf-review-env
 description: A Helm chart a Codefresh review envrionment app
 keywords:
@@ -10,4 +10,4 @@ maintainers:
 type: application
 sources:
 - https://github.com/FindHotel/cf-review-env
-version: 0.2.7
+version: 0.2.8

--- a/charts/cf-review-env/templates/deployment.yaml
+++ b/charts/cf-review-env/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        rollme: {{ randAlphaNum 5 | quote }}
     {{- end }}
       labels:
         {{- include "cf-review-env.selectorLabels" . | nindent 8 }}
@@ -34,9 +34,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           {{- if eq .Values.envFrom.enabled true }}
-          envFrom:
-            - secretRef:
-                name: {{ .Values.envFrom.secretRef.name }}
+          volumes:
+            - name: {{ include "cf-review-env.fullname" . }}
+              configMap:
+                name: {{ include "cf-review-env.fullname" . }}
           {{- end }}
           ports:
             - name: {{ .Values.deployment.ports.name }}

--- a/charts/cf-review-env/templates/deployment.yaml
+++ b/charts/cf-review-env/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       {{- include "cf-review-env.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+    {{- if eq .Values.podAnnotations.enabled true }}
       annotations:
         {{- toYaml . | nindent 8 }}
         rollme: {{ randAlphaNum 5 | quote }}

--- a/charts/cf-review-env/templates/deployment.yaml
+++ b/charts/cf-review-env/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
     {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     {{- end }}
       labels:
         {{- include "cf-review-env.selectorLabels" . | nindent 8 }}

--- a/charts/cf-review-env/templates/deployment.yaml
+++ b/charts/cf-review-env/templates/deployment.yaml
@@ -19,11 +19,9 @@ spec:
       {{- include "cf-review-env.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- if eq .Values.podAnnotations.enabled true }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        # Force all new release to recreate the pods #
         rollme: {{ randAlphaNum 5 | quote }}
-    {{- end }}
       labels:
         {{- include "cf-review-env.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/cf-review-env/templates/deployment.yaml
+++ b/charts/cf-review-env/templates/deployment.yaml
@@ -34,10 +34,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           {{- if eq .Values.envFrom.enabled true }}
-          volumes:
-            - name: {{ include "cf-review-env.fullname" . }}
-              configMap:
-                name: {{ include "cf-review-env.fullname" . }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.envFrom.secretRef.name }}
           {{- end }}
           ports:
             - name: {{ .Values.deployment.ports.name }}

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -2,7 +2,7 @@
 # exit if any command fails
 set -e
 
-chart_version=${CHART_VERSION:-0.2.7}
+chart_version=${CHART_VERSION:-0.2.8}
 helm_version=3.0.3
 chart_ref=cf-review-env
 short_name=$(echo -n $NAME | cut -c1-15)


### PR DESCRIPTION
Ref.: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments

- Chart bump version 0.2.8
- Added treatment to fix the problem on the secrets when they are updated and the pods don't.