### PR TITLE
[ch23748] Use annotation to store env data, fix for long branch names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cf-stop-k8s-env
+prune/prune

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+prune-build:
+	cd prune; go build -o prune

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -28,8 +28,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    app.kubernetes.io/instance: $NAMESPACE
     app.kubernetes.io/name: cf-review-env
+  annotations:
+    app.kubernetes.io/instance: $NAMESPACE
     app.kubernetes.io/pull_request_number: "$CF_PULL_REQUEST_NUMBER"
     app.kubernetes.io/branch_name: "$CF_BRANCH"
     app.kubernetes.io/repository_name: "$CF_REPO_NAME"

--- a/prune/main.go
+++ b/prune/main.go
@@ -260,12 +260,19 @@ func (k8s *K8sClient) NamespaceList() ([]K8sNamespace, error) {
 
 	nk8sNamespacesList := make([]K8sNamespace, 0)
 	for _, namespace := range namespaceList.Items {
+		// Backward compatibility layer. This can be removed once all
+		// envs using labels for storing data are purged.
+		data := namespace.Annotations
+		if _, ok := data["instance"]; !ok {
+			data = namespace.Labels
+		}
+
 		var updatedAt time.Time
-		updatedAtTimestamp := namespace.Labels["app.kubernetes.io/updated_at"]
+		updatedAtTimestamp := data["app.kubernetes.io/updated_at"]
 		if updatedAtTimestamp != "" {
 			updatedAtTimestamp, err := strconv.ParseInt(updatedAtTimestamp, 10, 64)
 			if err != nil {
-				log.Printf("Got bad data at updated_at label for namespace: %s", namespace.Name)
+				log.Printf("Got bad data at updated_at annotation for namespace: %s", namespace.Name)
 				continue
 			}
 
@@ -274,11 +281,11 @@ func (k8s *K8sClient) NamespaceList() ([]K8sNamespace, error) {
 
 		nk8sNamespacesList = append(nk8sNamespacesList, K8sNamespace{
 			UpdatedAt:         &updatedAt,
-			Name:              namespace.Labels["app.kubernetes.io/instance"],
-			BranchName:        namespace.Labels["app.kubernetes.io/branch_name"],
-			PullRequestNumber: namespace.Labels["app.kubernetes.io/pull_request_number"],
-			RepositoryName:    namespace.Labels["app.kubernetes.io/repository_name"],
-			RepositoryOwner:   namespace.Labels["app.kubernetes.io/repository_owner"],
+			Name:              data["app.kubernetes.io/instance"],
+			BranchName:        data["app.kubernetes.io/branch_name"],
+			PullRequestNumber: data["app.kubernetes.io/pull_request_number"],
+			RepositoryName:    data["app.kubernetes.io/repository_name"],
+			RepositoryOwner:   data["app.kubernetes.io/repository_owner"],
 		})
 	}
 	return nk8sNamespacesList, nil


### PR DESCRIPTION
https://app.clubhouse.io/findhotel/story/24359/remove-limit-of-63-characters-for-branch-name

Start using annotation instead of labels for data about the review env. This fix the problem with branches with long names.