### PR TITLE
[ch24337] Add support for calling pre/post hooks

### DIFF
--- a/deploy/deploy
+++ b/deploy/deploy
@@ -127,8 +127,12 @@ test_chart() {
 
 export_variables() {
   # It is necessary to export these variables because we are using it on the pipelines
+  url="https://$namespace.$APP_DOMAIN"
+  export URL=$url
+  export NAMESPACE=$namespace
+
   cf_export NAMESPACE="$namespace"
-  cf_export URL="https://$namespace.$APP_DOMAIN"
+  cf_export URL="$url"
   cf_export K8S_CONTEXT_NAME="$KUBE_CONTEXT"
 }
 

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -23,6 +23,9 @@ short_name=$(echo -n $name | cut -c1-15)
 hash=$(echo "$name" | rhash -p "%c" -)
 namespace=re-$short_name-$hash
 is_ephemeral=${APP_IS_EPHEMERAL:-true}
+host="$namespace.$APP_DOMAIN"
+url="https://$host"
+kube_context=$KUBE_CONTEXT
 
 config_context() {
   # kubectl locks the config for each execution. To workaround
@@ -30,7 +33,7 @@ config_context() {
   kubeconfig_dir=/codefresh/volume/sensitive/.kube-$namespace/
   cp -R /codefresh/volume/sensitive/.kube "${kubeconfig_dir}"
   export KUBECONFIG=${kubeconfig_dir}/config
-  kubectl config use-context "$KUBE_CONTEXT"
+  kubectl config use-context "$kube_context"
 }
 
 namespace_apply() {
@@ -70,7 +73,7 @@ apply_secret() {
 }
 
 generate_pull_secret() {
-  codefresh generate image-pull-secret --cluster "$KUBE_CONTEXT" --namespace "$namespace" \
+  codefresh generate image-pull-secret --cluster "$kube_context" --namespace "$namespace" \
     --registry "$APP_REGISTRY_NAME"
 }
 
@@ -86,7 +89,7 @@ install_chart() {
   ACTION=install \
   CHART_REPO_URL="$HELM_REPO_URL" \
   CHART_REF=$chart_ref \
-  KUBE_CONTEXT="$KUBE_CONTEXT" \
+  KUBE_CONTEXT="$kube_context" \
   RELEASE_NAME="$namespace" \
   CHART_VERSION="$chart_version" \
   HELM_VERSION=$helm_version \
@@ -94,9 +97,9 @@ install_chart() {
   CUSTOM_image_repository="$APP_IMAGE_URL" \
   CUSTOM_imagePullSecrets="$(kubectl get secret --namespace $namespace --field-selector='type=kubernetes.io/dockercfg' -o=jsonpath='{.items[0].metadata.name}')" \
   CUSTOM_envFrom_secretRef_name="$namespace" \
-  CUSTOM_"ingress_hosts[0]_host=$namespace.$APP_DOMAIN" \
+  CUSTOM_"ingress_hosts[0]_host=$host" \
   CUSTOM_"ingress_hosts[0]_paths[0]=/" \
-  CUSTOM_"ingress_tls[0]_hosts[0]=$namespace.$APP_DOMAIN" \
+  CUSTOM_"ingress_tls[0]_hosts[0]=$host" \
   SKIP_CF_STABLE_HELM_REPO=true \
   WAIT=true \
   /opt/bin/release_chart
@@ -110,7 +113,7 @@ test_chart() {
     SKIP_CF_STABLE_HELM_REPO=true \
     HELM_VERSION=$helm_version \
     CHART_VERSION="$chart_version" \
-    KUBE_CONTEXT="$KUBE_CONTEXT" \
+    KUBE_CONTEXT="$kube_context" \
     /opt/bin/release_chart
     helm test "$namespace" --namespace "$namespace"
 
@@ -126,14 +129,15 @@ test_chart() {
 }
 
 export_variables() {
-  # It is necessary to export these variables because we are using it on the pipelines
-  url="https://$namespace.$APP_DOMAIN"
+  # Export normally here so they are available to the post hook
   export URL=$url
   export NAMESPACE=$namespace
+  export K8S_CONTEXT_NAME=$kube_context
 
-  cf_export NAMESPACE="$namespace"
+  # It is necessary to export these variables because we are using it on the pipelines
   cf_export URL="$url"
-  cf_export K8S_CONTEXT_NAME="$KUBE_CONTEXT"
+  cf_export NAMESPACE="$namespace"
+  cf_export K8S_CONTEXT_NAME="$kube_context"
 }
 
 config_context

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -4,7 +4,7 @@ set -e
 
 if [ "$PRE_HOOK" != "" ]; then
   echo "Running pre hook command '%s': $PRE_HOOK"
-  exec "$PRE_HOOK"
+  sh -c "$PRE_HOOK"
 fi
 
 chart_version=${CHART_VERSION:-0.2.8}
@@ -142,5 +142,5 @@ export_variables
 
 if [ "$POST_HOOK" != "" ]; then
   echo "Running post hook command '%s': $POST_HOOK"
-  exec "$POST_HOOK"
+  sh -c "$POST_HOOK"
 fi

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -2,6 +2,11 @@
 # exit if any command fails
 set -e
 
+if [ "$PRE_HOOK" != "" ]; then
+  echo "Running pre hook command '%s': $PRE_HOOK"
+  exec "$PRE_HOOK"
+fi
+
 chart_version=${CHART_VERSION:-0.2.8}
 helm_version=3.0.3
 chart_ref=cf-review-env
@@ -134,3 +139,8 @@ generate_pull_secret
 install_chart
 test_chart
 export_variables
+
+if [ "$POST_HOOK" != "" ]; then
+  echo "Running post hook command '%s': $POST_HOOK"
+  exec "$POST_HOOK"
+fi

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -23,8 +23,8 @@ short_name=$(echo -n $name | cut -c1-15)
 hash=$(echo "$name" | rhash -p "%c" -)
 namespace=re-$short_name-$hash
 is_ephemeral=${APP_IS_EPHEMERAL:-true}
-host="$namespace.$APP_DOMAIN"
-url="https://$host"
+host=$namespace.$APP_DOMAIN
+url=https://$host
 kube_context=$KUBE_CONTEXT
 
 config_context() {

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -3,8 +3,8 @@
 set -e
 
 if [ "$PRE_HOOK" != "" ]; then
-  echo "Running pre hook command '%s': $PRE_HOOK"
-  sh -c "$PRE_HOOK"
+  echo "Running pre hook command: $PRE_HOOK"
+  eval "$PRE_HOOK"
 fi
 
 chart_version=${CHART_VERSION:-0.2.8}
@@ -141,6 +141,6 @@ test_chart
 export_variables
 
 if [ "$POST_HOOK" != "" ]; then
-  echo "Running post hook command '%s': $POST_HOOK"
-  sh -c "$POST_HOOK"
+  echo "Running post hook command: $POST_HOOK"
+  eval "$POST_HOOK"
 fi


### PR DESCRIPTION
Adds support for pre/post hook into the deploy script. This will be used by the github update script. This is useful because we can easily access the env vars of the environment.

My first attempt was to use codefresh hooks, but I could not find a way to tell the hooks which env was bein deployed.