### PR TITLE
[ch27047] - removed the secrets of the ECR repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,27 @@
-cf-review-env
-=============
+# cf-review-env
 
-Review environment support for CodeFresh using Kubernetes.
+Review environment support for [CodeFresh](http://codefresh.io/) using [Kubernetes](https://kubernetes.io/).
 
 ## Releases
 
-We use a very simple versioning model. The Docker image is always tagged with `latest` for the
-stable release (CD pipeline). During development the Docker image is tagged with `short commit hash`
-and `branch name` (CI pipeline).
+We use a very simple versioning model. The Docker image is always tagged with `latest` for the stable release (CD pipeline). During development the Docker image is tagged with `short commit hash` and `branch name` (CI pipeline).
 
-The Helm Chart version uses SemVer for stable releases, but during development the version
-is always `0.0.1:{SHORT_COMMIT_HASH}`.
+The Helm Chart version uses SemVer for stable releases, but during development the version is always `0.0.1:{SHORT_COMMIT_HASH}`.
 
 ## How to use the development version
 
-When the new `chart version` is created the CI pipeline run and push the new chart to the registry with the new version for example `0.0.1+87d6164` and then we can use this new version, but it is necessary to change it on the [deploy](https://github.com/FindHotel/cf-review-env/blob/master/deploy/deploy#L2) script and to run the CI pipeline to build the new `deploy script`.
+**Note**: We should always use the `staging` environment when it is necessary to test a new `helm chart version`.
+
+When the new `chart version` is created the CI pipeline run and push the new chart to the registry with the new version for example `0.0.1+87d6164` and we can use this new version following these steps:
+
+1 - Choose the project development pipeline that you would like to test (e.g.: [geolocation-service-lab](https://g.codefresh.io/projects/geolocation-service-lab/edit/pipelines/?projectId=5fbf87e2b4b6c926b5fe6ebc))
+
+2 - Run a new deployment but first you need to add these variables in `BUILD VARIABLES`:
+
+| Variable  | Value |
+|----- |-------|
+| KUBE_CONTEXT | k8s-fh-ci-stg |
+| APP_DOMAIN | shared-stg.fih.io |
+| CHART_VERSION | 0.0.1+87d6164 |
+
+**Note**: The value of the `CHART_VERSION` variable, you must add the new version of the chart created for testing.

--- a/README.md
+++ b/README.md
@@ -23,5 +23,6 @@ When the new `chart version` is created the CI pipeline run and push the new cha
 | KUBE_CONTEXT | k8s-fh-ci-stg |
 | APP_DOMAIN | shared-stg.fih.io |
 | CHART_VERSION | 0.0.1+87d6164 |
+| CF_REVIEW_ENV_IMAGE_TAG | YOUR_BRANCH_NAME |
 
 **Note**: The value of the `CHART_VERSION` variable, you must add the new version of the chart created for testing.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ When the new `chart version` is created the CI pipeline run and push the new cha
 
 | Variable  | Value |
 |----- |-------|
-| KUBE_CONTEXT | k8s-fh-ci-stg |
-| APP_DOMAIN | shared-stg.fih.io |
+| KUBE_CONTEXT | k8s-context |
+| APP_DOMAIN | k8s-domain |
 | CHART_VERSION | 0.0.1+87d6164 |
-| CF_REVIEW_ENV_IMAGE_TAG | YOUR_BRANCH_NAME |
+| CF_REVIEW_ENV_IMAGE_TAG | your-branch-name |
 
 **Note**: The value of the `CHART_VERSION` variable, you must add the new version of the chart created for testing.

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,0 @@
-# TODO
-
-## Use startupProbe on the deployments
-
-We need to use the `startupProbe` in our deployments, but this new feature will be available only on `EKS version 1.18`, so now we have it added in our [deployment.yaml](https://github.com/FindHotel/cf-review-env/blob/master/charts/cf-review-env/templates/deployment.yaml#L62) file but we can't use it.
-**Note:** According to AWS the `EKS 1.18 version` will be available on `October, 2020`.
-
-Issue: https://github.com/aws/containers-roadmap/issues/947
-AWS Roadmap: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar

--- a/charts/cf-review-env/Chart.yaml
+++ b/charts/cf-review-env/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.2.11
+appVersion: 0.2.12
 name: cf-review-env
 description: A Helm chart a Codefresh review envrionment app
 keywords:
@@ -10,4 +10,4 @@ maintainers:
 type: application
 sources:
 - https://github.com/FindHotel/cf-review-env
-version: 0.2.11
+version: 0.2.12

--- a/charts/cf-review-env/templates/deployment.yaml
+++ b/charts/cf-review-env/templates/deployment.yaml
@@ -94,8 +94,6 @@ spec:
         - name: docker-store
           emptyDir: {}
       {{- end }}
-      imagePullSecrets:
-        - name: {{ .Values.imagePullSecrets }}
       serviceAccountName: {{ include "cf-review-env.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -7,7 +7,7 @@ if [ "$PRE_HOOK" != "" ]; then
   eval "$PRE_HOOK"
 fi
 
-chart_version=${CHART_VERSION:-0.2.11}
+chart_version=${CHART_VERSION:-0.2.12}
 helm_version=3.0.3
 chart_ref=cf-review-env
 
@@ -60,7 +60,6 @@ metadata:
 EOF
 }
 
-
 apply_secret() {
   # If the user doesn't have secrets we need to generate an empty file
   # to make our chart happy, without this the deployment breaks
@@ -68,13 +67,7 @@ apply_secret() {
     touch /codefresh/volume/secrets.env
   fi
 
-  kubectl create secret generic "$namespace" --from-env-file=/codefresh/volume/secrets.env \
-    --dry-run=client -o yaml --save-config=true --namespace "$namespace" | kubectl apply -f -
-}
-
-generate_pull_secret() {
-  codefresh generate image-pull-secret --cluster "$kube_context" --namespace "$namespace" \
-    --registry "$APP_REGISTRY_NAME"
+  kubectl create secret generic "$namespace" --from-env-file=/codefresh/volume/secrets.env --dry-run=client -o yaml --save-config=true --namespace "$namespace" | kubectl apply -f -
 }
 
 install_chart() {
@@ -95,7 +88,6 @@ install_chart() {
   HELM_VERSION=$helm_version \
   CUSTOM_image_tag="$APP_IMAGE_TAG" \
   CUSTOM_image_repository="$APP_IMAGE_URL" \
-  CUSTOM_imagePullSecrets="$(kubectl get secret --namespace $namespace --field-selector='type=kubernetes.io/dockercfg' -o=jsonpath='{.items[0].metadata.name}')" \
   CUSTOM_envFrom_secretRef_name="$namespace" \
   CUSTOM_"ingress_hosts[0]_host=$host" \
   CUSTOM_"ingress_hosts[0]_paths[0]=/" \
@@ -143,7 +135,6 @@ export_variables() {
 config_context
 namespace_apply
 apply_secret
-generate_pull_secret
 install_chart
 test_chart
 export_variables


### PR DESCRIPTION
https://app.clubhouse.io/findhotel/story/27047/remove-the-step-to-create-the-secrets-in-eks-for-all-deployments

- removed the secrets of the ECR repositories
- new bump version 0.2.12
- updated readme file
- removed TODO file, it's no longer necessary

Job: https://g.codefresh.io/build/5fdc88f22b1c4c892ea70de0
Note: It was deployed in the staging environment

<img width="988" alt="Screen Shot 2020-12-18 at 11 55 10 AM" src="https://user-images.githubusercontent.com/61460404/102607007-e49daa00-4127-11eb-9715-864f5dad53d6.png">
