### PR TITLE
Prefix url variable with the app prefix

### DIFF
--- a/deploy/deploy
+++ b/deploy/deploy
@@ -123,13 +123,17 @@ test_chart() {
 export_variables() {
   # Export normally here so they are available to the post hook
   export URL=$url
-  export NAMESPACE=$namespace
-  export K8S_CONTEXT_NAME=$kube_context
 
   # It is necessary to export these variables because we are using it on the pipelines
   cf_export URL="$url"
-  cf_export NAMESPACE="$namespace"
-  cf_export K8S_CONTEXT_NAME="$kube_context"
+
+  # If APP_PREFIX is available we used it to prefix the exported variables
+  # This is useful when multiple deployments are done in the same pipeline.
+  # In such situation each deployment would override the variable of previous one.
+  if [ "$APP_PREFIX" != "" ]; then
+    export "$APP_PREFIX"_URL="$url"
+    cf_export "$APP_PREFIX"_URL="$url"
+  fi
 }
 
 config_context


### PR DESCRIPTION
This is a requirement that came up with the work that @gabrielmanara is doing to add end to end tests to the website. In such situation we need to know the url of each env deployed. Because they might override one another we need this prefix.