### PR TITLE
Replace dash by underscore when using app prefix to create url var

### DIFF
--- a/deploy/deploy
+++ b/deploy/deploy
@@ -131,8 +131,10 @@ export_variables() {
   # This is useful when multiple deployments are done in the same pipeline.
   # In such situation each deployment would override the variable of previous one.
   if [ "$APP_PREFIX" != "" ]; then
-    export "$APP_PREFIX"_URL="$url"
-    cf_export "$APP_PREFIX"_URL="$url"
+    # Replace dash (-) from app prefix by underscore (_)
+    valid_app_prefix=$(echo "bofh-api" | sed 's/\-/\_/g')
+    export "$valid_app_prefix"_URL="$url"
+    cf_export "$valid_app_prefix"_URL="$url"
   fi
 }
 

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -132,7 +132,7 @@ export_variables() {
   # In such situation each deployment would override the variable of previous one.
   if [ "$APP_PREFIX" != "" ]; then
     # Replace dash (-) from app prefix by underscore (_)
-    valid_app_prefix=$(echo "bofh-api" | sed 's/\-/\_/g')
+    valid_app_prefix=$(echo "$APP_PREFIX" | sed 's/\-/\_/g')
     export "$valid_app_prefix"_URL="$url"
     cf_export "$valid_app_prefix"_URL="$url"
   fi


### PR DESCRIPTION
In cases where the app prefix has a dash (-) we need to replace by underscore (_) as dash is not a valid var name.